### PR TITLE
feat: add support to attributes anywhere

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -170,11 +170,6 @@ impl<'s> Display for MapItem<'s> {
     }
 }
 
-// Helper struct to format attribute list - no longer needed with custom Display
-// #[derive(Debug, PartialEq)]
-// #[cfg_attr(test, derive(serde::Serialize))]
-// pub struct AttributeList<'s>(pub Option<Vec<WsLead<'s, crate::InlineAttribute<'s>>>>);
-
 #[apply(ast)]
 #[derive(Display)]
 #[display(fmt = "{{{_0}}}")]

--- a/tests/input/inline_attributes.ron
+++ b/tests/input/inline_attributes.ron
@@ -1,0 +1,7 @@
+{
+  #[repeat = 5]
+  #[schema = "DbSchema"]  
+  DbTable: ["item1", "item2", "item3"],
+  
+  normal_field: "no_attributes"
+}

--- a/tests/input/simple_test.ron
+++ b/tests/input/simple_test.ron
@@ -1,0 +1,3 @@
+{
+  simple_field: "value"
+}

--- a/tests/snapshots/ron_edit__test__sensible.ron.snap
+++ b/tests/snapshots/ron_edit__test__sensible.ron.snap
@@ -76,6 +76,7 @@ File(
                         Space("\n        "),
                       ]),
                       content: MapItem(
+                        attributes: None,
                         key: Unit("A"),
                         after_key: Whitespace([]),
                         value: WsLead(
@@ -92,6 +93,7 @@ File(
                         Space("\n        "),
                       ]),
                       content: MapItem(
+                        attributes: None,
                         key: List(List(Separated(
                           values: [
                             WsWrapped(

--- a/tests/snapshots/ron_edit__test__simple_test.ron.snap
+++ b/tests/snapshots/ron_edit__test__simple_test.ron.snap
@@ -1,0 +1,36 @@
+---
+source: src/lib.rs
+expression: ron
+---
+File(
+  extentions: [],
+  value: WsLead(
+    leading: Whitespace([]),
+    content: Map(Map(Separated(
+      values: [
+        WsWrapped(
+          leading: Whitespace([
+            Space("\n  "),
+          ]),
+          content: MapItem(
+            attributes: None,
+            key: Unit("simple_field"),
+            after_key: Whitespace([]),
+            value: WsLead(
+              leading: Whitespace([
+                Space(" "),
+              ]),
+              content: Str(Baked("value")),
+            ),
+          ),
+          following: Whitespace([
+            Space("\n"),
+          ]),
+        ),
+      ],
+      trailing_comma: false,
+      trailing_ws: Whitespace([]),
+    ))),
+  ),
+  trailing_ws: Whitespace([]),
+)


### PR DESCRIPTION
Some time ago, I opened an issue to discuss attribute support anywhere in the file, as I needed it for my [GrowRS](https://github.com/Wilovy09/Grow-rs/tree/develop) project.
I thought I had made a PR, but I hadn't, so here it is.
```ron
// Example of how I use it in the aforementioned personal project
{
    // Static data
    User: [
        (
            column_name: "value",
        )
    ],

    // Schema qualified tables using inline attributes
    #[schema = "public"] roles: [
        (
            name: "admin",
            permissions: "all",
        )
    ],

    // Repeated data using inline attributes
    #[repeat = 4] User: {
        "username": "user_{i}",
        "password": "hashed_password_{i}",
    },

    // Schema qualified repeated data (multiline attributes)
    #[repeat = 5]
    #[schema = "catalogs"]
    products: {
        "name": "{fake(WORD)}",
        "description": "{fake(WORD)}",
        "price_cents": 10000,
        "currency": "mxn",
    },

    // Single line attributes (also supported)
    #[repeat = 3] #[schema = "inventory"] items: {
        "sku": "ITEM_{i}",
        "quantity": 100,
    },
}
```